### PR TITLE
refactor Flags.validate in src/flags.js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-	"extends": "nodebb"
+	"extends": "nodebb",
+	"parserOptions": {
+		"ecmaVersion": 2020 // This change in configuration is suggested by Copilot
+	}
 }

--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,4 +1,4 @@
 reporter: dot
 timeout: 25000
 exit: true
-bail: true
+bail: false

--- a/src/flags.js
+++ b/src/flags.js
@@ -273,6 +273,13 @@ Flags.sort = async function (flagIds, sort) {
 	return flagIds;
 };
 
+function checkSelfFlagError(payload) {
+	console.log('CHEYU TU - checkSelfFlagError');
+	if (parseInt(payload.id, 10) === parseInt(payload.uid, 10)) {
+		throw new Error('[[error:cant-flag-self]]');
+	}
+}
+
 Flags.validate = async function (payload) {
 	const [target, reporter] = await Promise.all([
 		Flags.getTarget(payload.type, payload.id, payload.uid),
@@ -283,7 +290,7 @@ Flags.validate = async function (payload) {
 		throw new Error('[[error:invalid-data]]');
 	} else if (target.deleted) {
 		throw new Error('[[error:post-deleted]]');
-	} else if (!reporter || !reporter.userslug) {
+	} else if (!reporter?.userslug) {
 		throw new Error('[[error:no-user]]');
 	} else if (reporter.banned) {
 		throw new Error('[[error:user-banned]]');
@@ -304,9 +311,7 @@ Flags.validate = async function (payload) {
 			throw new Error(`[[error:not-enough-reputation-to-flag, ${meta.config['min:rep:flag']}]]`);
 		}
 	} else if (payload.type === 'user') {
-		if (parseInt(payload.id, 10) === parseInt(payload.uid, 10)) {
-			throw new Error('[[error:cant-flag-self]]');
-		}
+		checkSelfFlagError(payload);
 		const editable = await privileges.users.canEdit(payload.uid, payload.id);
 		if (!editable && !meta.config['reputation:disabled'] && reporter.reputation < meta.config['min:rep:flag']) {
 			throw new Error(`[[error:not-enough-reputation-to-flag, ${meta.config['min:rep:flag']}]]`);

--- a/test/flags.js
+++ b/test/flags.js
@@ -754,6 +754,37 @@ describe('Flags', () => {
 				done();
 			});
 		});
+
+		function validateUserFlag(done) {
+			Flags.validate({
+				type: 'user',
+				id: 1,
+				uid: 3,
+			}, (err) => {
+				assert.ok(err);
+				assert.strictEqual('[[error:not-enough-reputation-to-flag, 50]]', err.message);
+				Meta.configs.set('min:rep:flag', 0, done);
+			});
+		}
+
+		it('should not pass validation if type is user, flag threshold is set and user rep does not meet it', (done) => {
+			Meta.configs.set('min:rep:flag', '50', (err) => {
+				assert.ifError(err);
+				validateUserFlag(done);
+			});
+		});
+
+		it('should throw an error if user tries to flag themselves', (done) => {
+			Flags.validate({
+				type: 'user',
+				id: 1,
+				uid: 1,
+			}, (err) => {
+				assert.ok(err);
+				assert.strictEqual('[[error:cant-flag-self]]', err.message);
+				done();
+			});
+		});
 	});
 
 	describe('.appendNote()', () => {


### PR DESCRIPTION
Refactor Flags.validate() in src/flag.js to reduce its Cognitive Complexity by adding a helper function 'checkSelfFlagError' to replace a nested function and an optional chaining to remove unnecessary checks.
Also added test cases for the refactored code.
Recreated the PR after removing the dump.rdb file, which has merge conflict with the main branch.